### PR TITLE
PKCS7 improvements

### DIFF
--- a/src/cipher/aes_128_cbc.rs
+++ b/src/cipher/aes_128_cbc.rs
@@ -62,7 +62,10 @@ pub fn decrypt(ciphertext: &[u8], key: &[u8], iv: &[u8]) -> Result<Vec<u8>, Box<
         result.append(&mut decrypted);
         last_block = block.to_vec();
     }
-    Ok(pkcs7::unpad(&result))
+    match pkcs7::unpad(&result, iv.len()) {
+        Ok(v) => Ok(v),
+        Err(e) => panic!("{}", e)
+    }
 }
 
 #[cfg(test)]

--- a/src/pkcs7.rs
+++ b/src/pkcs7.rs
@@ -2,13 +2,7 @@
 pub mod pkcs7 {
     pub fn pad(input: &[u8], key_size: usize) -> Vec<u8> {
         let pad_num: usize;
-        if input.len() == key_size {
-            pad_num = key_size;
-        } else if input.len() < key_size {
-            pad_num = key_size - input.len();
-        } else {
-            pad_num = key_size - (input.len() % key_size);
-        }
+        pad_num = key_size - (input.len() % key_size);
         [input.to_vec(), vec![pad_num as u8; pad_num]].concat()
     }
     

--- a/src/pkcs7.rs
+++ b/src/pkcs7.rs
@@ -26,18 +26,18 @@ pub mod pkcs7 {
     }
     
     pub fn unpad(input: &[u8], key_size: usize) -> Result<Vec<u8>> {
-        let pad_num = input.last().unwrap();
-        if *pad_num == 0 as u8 || *pad_num as usize > key_size {
+        let pad_num = *input.last().unwrap() as usize;
+        if pad_num == 0 || pad_num  > key_size {
             // invalid padding character
             return Err(Pkcs7UnpadError)
         }
-        for i in input[input.len() - *pad_num as usize..input.len()].to_vec() {
-            if i != *pad_num {
+        for i in input[input.len() - pad_num..input.len()].to_vec() {
+            if i != pad_num as u8 {
                 // inconsistent padding
                 return Err(Pkcs7UnpadError)
             }
         }
-        Ok(input[0..input.len() - *pad_num as usize].to_vec())
+        Ok(input[0..input.len() - pad_num].to_vec())
     }
 
     #[cfg(test)]

--- a/src/pkcs7.rs
+++ b/src/pkcs7.rs
@@ -84,6 +84,13 @@ pub mod pkcs7 {
             let result = unpad(&input, 7).unwrap(); 
             assert_eq!(vec![0, 0, 0], result);
         }
+
+        #[test]
+        #[should_panic]
+        fn test_unpad_invalid_input() {
+            let input = vec![0, 0, 0, 0, 0, 4, 4, 4];
+            unpad(&input, 8).unwrap();
+        }
             
     }
 }

--- a/src/pkcs7.rs
+++ b/src/pkcs7.rs
@@ -74,20 +74,16 @@ pub mod pkcs7 {
         #[test]
         fn test_unpad_single_byte() {
             let input = vec![0, 0, 0, 1];
-            match unpad(&input, 4) {
-                Ok(v) => assert_eq!(vec![0, 0, 0], v),
-                Err(e) => panic!("{}", e)
-            }
+            let result = unpad(&input, 4).unwrap();
+            assert_eq!(vec![0, 0, 0], result);
         }
 
         #[test]
         fn test_unpad_multi_byte() {
             let input = vec![0, 0, 0, 4, 4, 4, 4];
-            match unpad(&input, 7) {
-                Ok(v) => assert_eq!(vec![0, 0, 0], v),
-                Err(e) => panic!("{}", e)
-            };
-            
+            let result = unpad(&input, 7).unwrap(); 
+            assert_eq!(vec![0, 0, 0], result);
         }
+            
     }
 }

--- a/src/set2/challenge12.rs
+++ b/src/set2/challenge12.rs
@@ -66,7 +66,10 @@ mod tests {
             }
         }
 
-        let final_message = pkcs7::unpad(message.as_ref());
-        assert_eq!(UNKNOWN_STRING.to_vec(), final_message);
+        match pkcs7::unpad(message.as_ref(), block_size) {
+            Ok(v) => assert_eq!(UNKNOWN_STRING.to_vec(), v),
+            Err(e) => panic!("{}", e)
+        };
+        
     }
 }


### PR DESCRIPTION
Updates the PKCS7 `unpad()` function to perform input validation and raise a new `Pkcs7UnpadError` if the input is not properly formatted PKCS7. Updates usages of the function to provide the appropriate block_size input and handle the new `Result<>` output.

Style changes to the PKCS7 `pad()` function to remove unneeded if-logic.

Fixes #1 